### PR TITLE
Bug fixes

### DIFF
--- a/bin/zulu.py
+++ b/bin/zulu.py
@@ -1483,8 +1483,11 @@ class MainPanel(wx.Panel):
 		data = fp.read()
 		try:
 			temp = []
-			temp = path.split('.')
-			self.file_extension = temp[len(temp)-1]
+			temp = os.path.basename(path).split('.')
+			if len(temp) < 1:
+				self.file_extension = temp[len(temp)-1]
+			else:
+				self.file_extension = ''
 		except:
 			pass
 		tmp_list = []

--- a/bin/zulu.py
+++ b/bin/zulu.py
@@ -1643,7 +1643,7 @@ class MainPanel(wx.Panel):
 			try:
 				event = debug.wait(1000)
 			except WindowsError, e:
-				if win32.winerror(e) in (win32.ERROR_SEM_TIMEOUT, win32.WAIT_TIMEOUT):
+				if ctypes.winerror(e) in (ctypes.ERROR_SEM_TIMEOUT, ctypes.WAIT_TIMEOUT):
 					continue
 				raise
 			try:


### PR DESCRIPTION
1. The bug exist if there is a dot in directory path but no extension for filename. It splits the directory path and append it to the filepath thinking of it as extension and throws 'Error creating fuzz file'.
2. win32.winerror() did not work in my system. Maybe configuration differ, but advisable to check it.

System: Windows 7
