### PR TITLE
Update packet list if dealing with ZuluScript.

### DIFF
--- a/bin/zulu.py
+++ b/bin/zulu.py
@@ -3543,6 +3543,7 @@ class MainPanel(wx.Panel):
 					while y < len (self.modified_data):
 						data += self.modified_data[y]
 						y+=1
+                                        packet_data_list[x][1] = data
 				#------ Update length fields -------------------------------------------------
 				if len(self.LengthFields) > 0:
 					fuzzpoint_size = fuzz_packet_end - fuzz_packet_start + 1


### PR DESCRIPTION
Noticed on tcpdump(8) that when using a custom.py the packets were being sent unmodified.
This changes the packet data list with the data modified by a ZuluScript.